### PR TITLE
added push_set_upstream_, push_force_ commands

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -471,6 +471,43 @@ class Command:
             self.show_memo(text, _('Git: Result of push'))
         self.request_update(ed, 'pushed')
 
+    def push_set_upstream_(self):
+        if not self.is_git():
+            return msg_status(_('No Git repo'))
+
+        remotes = self.run_git(['remote','show']).splitlines()
+        index = dlg_menu(DMENU_LIST, remotes, caption=_('Select a remote to push to'))
+        if index is None:
+            return
+
+        remote = remotes[index]
+        branch = gitmanager.branch()
+
+        res = msg_box(
+            _("Do you really want to run 'git push --set-upstream {} {}'?").format(remote,branch),
+            MB_OKCANCEL+MB_ICONQUESTION
+        )
+        if res == ID_OK:
+            text = self.run_git(["push",'--set-upstream',remote,branch])
+            if text:
+                self.show_memo(text, _('Git: push --set-upstream {} {}').format(remote,branch))
+            self.request_update(ed, 'pushed_set_upstream')
+
+    def push_force_(self):
+        if not self.is_git():
+            return msg_status(_('No Git repo'))
+
+        res = msg_box(
+            _("Do you really want to run 'git push --force'?"),
+            MB_OKCANCEL+MB_ICONQUESTION
+        )
+        if res == ID_OK:
+            text = self.run_git(['push','--force'])
+            if text:
+                self.show_memo(text, _('Git: Result of push --force'))
+            self.request_update(ed, 'pushed_force')
+
+
     def pull_(self):
         if not self.is_git():
             return msg_status(_('No Git repo'))

--- a/install.inf
+++ b/install.inf
@@ -108,15 +108,25 @@ method=push_
 
 [item53]
 section=commands
+caption=Git Status\Push (set upstream)
+method=push_set_upstream_
+
+[item54]
+section=commands
+caption=Git Status\Push (force)
+method=push_force_
+
+[item55]
+section=commands
 caption=Git Status\View file changes
 method=diff_
 
-[item54]
+[item56]
 section=commands
 caption=Git Status\View all changes
 method=diff_all_
 
-[item55]
+[item57]
 section=commands
 caption=Git Status\-
 method=_


### PR DESCRIPTION
Added this as commands, but not adding as status bar menu items.
I don't know how to deal with enabled/disabled state there yet.
but generally didn't want to clutter status bar menu with similar items (push/push (set upstream)/push (force))
They are always accessible from Plugins menu and from Command palette.

PS: `push_` command that was already existed was asking for parameters, but adding '--force' to input box did nothing, because push_ ignores any additional parameters:
```python
if len(s) == 2:
    push_params += s
```
only 2 parameters are included. but `--force` is a 3rd one.
so `push_` command can't be used with '--force'. thats why I added separate command `push_force_`