### PR TITLE
shorter git log format

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -397,7 +397,7 @@ class Command:
     def get_log_(self):
         count = 100
         text = self.run_git([
-            '--no-pager', 'log', '--decorate=short', '--pretty=oneline', '--max-count=%d'%count,
+            '--no-pager', 'log', '--pretty=format:%h  %s%d', '--max-count=%d'%count,
         ])
 
         if text:
@@ -409,7 +409,7 @@ class Command:
         count = 100
         filename_ = ed.get_filename()
         text = self.run_git([
-            '--no-pager', 'log', '--decorate=short', '--pretty=oneline', '--max-count=%d'%count,
+            '--no-pager', 'log', '--pretty=format:%h  %s%d', '--max-count=%d'%count,
             filename_])
 
         if text:


### PR DESCRIPTION
- removed '--decorate=short'
'--decorate=short' was not working with '--pretty=oneline' (only when using '--oneline')
- changed '--pretty=oneline' to '--pretty=format:%h  %s%d', i think it will be better for reading:
now format is: short hash, message and then refs.

before:

![image](https://user-images.githubusercontent.com/275333/171997957-c2eea3ce-72d0-46c8-a230-e237e5d745a1.png)

after:

![image](https://user-images.githubusercontent.com/275333/171997927-72809b8c-f37a-4c8e-a271-5f10d3fc9eee.png)
