### PR TITLE
fixes for empty repository

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -534,7 +534,10 @@ class Command:
             return msg_status(_('No Git repo'))
 
         fn = ed.get_filename()
-        diffs = self.run_git(["diff", "HEAD", fn])
+        if gitmanager.commit_count() > 0:
+            diffs = self.run_git(["diff", "HEAD", fn])
+        else:
+            diffs = self.run_git(["diff", '--staged', fn])
         if not diffs:
             msg_box(_('No Git changes'), MB_OK+MB_ICONINFO)
             return
@@ -545,7 +548,10 @@ class Command:
         if not self.is_git():
             return msg_status(_('No Git repo'))
 
-        diffs = self.run_git(["diff", "HEAD"])
+        if gitmanager.commit_count() > 0:
+            diffs = self.run_git(["diff", "HEAD"])
+        else:
+            diffs = self.run_git(["diff",'--staged'])
         if not diffs:
             msg_box(_('No Git changes'), MB_OK+MB_ICONINFO)
             return

--- a/git_manager.py
+++ b/git_manager.py
@@ -78,8 +78,14 @@ class GitManager:
             return ''
 
     def is_dirty(self):
-        (exit_code, output) = self.run_git(["diff-index", "--quiet", "HEAD"])
+        (exit_code, output) = self.run_git(["diff-index", "--quiet", "HEAD"], silence_errors=True)
         return exit_code == 1
+
+    def commit_count(self):
+        (exit_code, output) = self.run_git(["rev-list", "--count", "HEAD"], silence_errors=True)
+        if exit_code != 0:
+            return 0
+        return int(output)
 
     ### This code shows dirty state when we have untacked files, bad.
     #def is_dirty(self):


### PR DESCRIPTION
some tweaks for empty repository (0 commits, HEAD is "unknown path"):
- we can use `diff --staged` instead of `diff HEAD`.
- added `silence_errors=True` for `is_dirty` function. (because HEAD is unknown)