### PR TITLE
fixed: "Add file..." menu item was always disabled for the files in subdirs (on Windows)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -239,7 +239,7 @@ class Command:
 
 
         fn = ed.get_filename()
-        fn_rel = git_relative_path(fn)
+        fn_rel = git_relative_path(fn).replace(os.path.sep, '/') # convert Windows-style path separators to Unix-style (used in git)
         branch = gitmanager.branch()
         diffs = bool(gitmanager.diff(fn))
         dirty = gitmanager.is_dirty()

--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,3 +1,5 @@
+2022.06.09
+- fix: "Add file..." menu item was always disabled for the files in subdirs (on Windows) (by @veksha)
 
 2022.06.08
 + add: menu item "Plugins / Git Status / Rebase (interactive)" (by @veksha and Alexey T.)


### PR DESCRIPTION
I think this change is platform-independent. no need for `if IS_WIN` here?