### PR TITLE
fixed "not a git repository" error

### DIFF
--- a/git_manager.py
+++ b/git_manager.py
@@ -152,13 +152,13 @@ class GitManager:
         return lines_
 
     def badge(self, filename):
-        self.filename = filename
-        if not self.filename:
+        if not filename:
             return ""
         if not os.path.isfile(filename):
             return ""
 
-        self.diff(self.filename)
+        self.filename = filename
+        self.diff(filename)
 
         branch = self.branch()
         if not branch:


### PR DESCRIPTION
sometimes you can get this error when clicking on git_status icon:
![image](https://user-images.githubusercontent.com/275333/195437412-bcb6b15a-8210-491d-a966-f23789eceb13.png)

### repro:
in your saved session you must have some file (which is in git repo) **and** Untitled1 tab with some text (unsaved tab)
activate tab with file which is in git repo and restart.
git_status will place icon in status bar for current file, but if you click on it you will see an error.

### what is happening:
on Cud startup `git_status` addon tries to update "badge" for two files: current opened filename and **empty filename** (because I have unsaved ("Untitled1") tab opened too and Cud sends **on_change_slow** for this Untitled1 tab! Why?? Cud's bug?)

### fix for git_status:
this line must be moved a little lower in the code.
`self.filename = filename`
in this case empty filename will not be saved inside "self.filename" which is used later to get current working directory (on git icon click)