### PR TITLE
another fix for "not a git repo" error

### DIFF
--- a/git_manager.py
+++ b/git_manager.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 from cudatext import *
 
+LOG = False
 MY_DECOR_COLOR = 0xFF
 DIFF_TAG = app_proc(PROC_GET_UNIQUE_TAG, '')
 
@@ -156,6 +157,10 @@ class GitManager:
             return ""
         if not os.path.isfile(filename):
             return ""
+        if filename != ed.get_filename():
+            return
+            
+        pass;       LOG and print("getting badge:", filename)
 
         self.filename = filename
         self.diff(filename)


### PR DESCRIPTION
https://user-images.githubusercontent.com/275333/197125095-8ee658b6-cc47-413e-9ca6-76081629402a.mp4

to reproduce:
- open two files (from different repos/folders)
- then **very quickly** do this actions:
- change one file and save (ctrl+s), select other file and click on git badge. (then click again)

fix:
- do not allow calling "badge" func when current editor is not the same.

