### PR TITLE
remove GIT environment vars if any

### DIFF
--- a/git_manager.py
+++ b/git_manager.py
@@ -19,6 +19,9 @@ class GitManager:
             self.last_error = ''
             cmd = [self.git] + args
             cwd = self.getcwd()
+            my_env = os.environ.copy()
+            # removing GIT environment vars if any, they are interfering with our git calls
+            my_env = { k:v for k,v in my_env.items() if not k.upper().startswith('GIT_') }
             if os.name=='nt':
                 # make sure console does not come up
                 startupinfo = subprocess.STARTUPINFO()
@@ -28,9 +31,9 @@ class GitManager:
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
                                      cwd=cwd,
-                                     startupinfo=startupinfo)
+                                     startupinfo=startupinfo,
+                                     env=my_env)
             else:
-                my_env = os.environ.copy()
                 my_env["PATH"] = "/usr/local/bin:/usr/bin:" + my_env["PATH"]
                 my_env["LANG"] = "en_US"
                 p = subprocess.Popen(cmd,


### PR DESCRIPTION
`git_status` addon breaks when CudaText is launched from another app that propagates its GIT env vars.
(CudaText is used as a diff tool in this app)

for example, `Git Extensions` tool pollutes environment with the following vars.

```json
{
    "GIT_DIFFTOOL_NO_PROMPT": "true",
    "GIT_DIFFTOOL_TRUST_EXIT_CODE": "false",
    "GIT_DIFF_PATH_COUNTER": "1",
    "GIT_DIFF_PATH_TOTAL": "1",
    "GIT_DIR": "F:/MySSDPrograms/CudaText_up/src/CudaText/.git",
    "GIT_EXEC_PATH": "C:/Program Files/Git/mingw64/libexec/git-core",
    "GIT_EXTERNAL_DIFF": "git-difftool--helper",
    "GIT_MERGETOOL_GUI": "true",
    "GIT_PAGER": "",
    "GIT_PREFIX": ".",
    "GIT_WORK_TREE": "F:/MySSDPrograms/CudaText_up/src/CudaText"
}
```

in this patch I remove this vars from environment before calling `git` process.
otherwise, git_status will break.